### PR TITLE
fix: responsive pages

### DIFF
--- a/components/FullSection/index.tsx
+++ b/components/FullSection/index.tsx
@@ -7,7 +7,7 @@ export const FullSection = ({children, id}: FullSectionProps) => {
   return (
     <section
       id={id}
-      className="flex flex-col justify-center items-center h-screen bg-gray-900 text-gray-100 p-8 sm:p-48"
+      className="w-full flex flex-col justify-center items-center bg-gray-900 text-gray-100 p-8"
     >
       {children}
     </section>

--- a/components/FullSection/index.tsx
+++ b/components/FullSection/index.tsx
@@ -7,7 +7,7 @@ export const FullSection = ({children, id}: FullSectionProps) => {
   return (
     <section
       id={id}
-      className="w-full flex flex-col justify-center items-center bg-gray-900 text-gray-100 p-8"
+      className="min-h-screen flex flex-col justify-center items-center bg-gray-900 text-gray-100 p-8"
     >
       {children}
     </section>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -6,7 +6,7 @@ import Link from "next/link";
 
 const Home: NextPage = () => {
   return (
-    <div className="h-screen bg-gray-900">
+    <div>
       <Head>
         <title>wecraftcode.org</title>
         <meta
@@ -17,7 +17,7 @@ const Home: NextPage = () => {
         <link rel="icon" href="/favicon/favicon-16x16.png" />
       </Head>
       <FullSection id="main">
-        <Stack>
+        <div className="w-3/4 lg:w-1/3">
           <Image
             src="/images/logo_and_text.png"
             height={500}
@@ -25,7 +25,7 @@ const Home: NextPage = () => {
             alt="wecraftcode"
             layout='intrinsic'
           />
-        </Stack>
+        </div>
         <Stack className="text-center">
           <div className="py-4 lg:text-4xl lg:max-w-[800px]">
             We are a small group of people who leverage learning and programming

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -23,7 +23,7 @@ const Home: NextPage = () => {
             height={500}
             width={680}
             alt="wecraftcode"
-            layout='intrinsic'
+            layout='responsive'
           />
         </div>
         <Stack className="text-center">

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -6,7 +6,7 @@ import Link from "next/link";
 
 const Home: NextPage = () => {
   return (
-    <div>
+    <div className="h-screen bg-gray-900">
       <Head>
         <title>wecraftcode.org</title>
         <meta
@@ -17,12 +17,15 @@ const Home: NextPage = () => {
         <link rel="icon" href="/favicon/favicon-16x16.png" />
       </Head>
       <FullSection id="main">
-        <Image
-          src="/images/logo_and_text.png"
-          height={500}
-          width={680}
-          alt="wecraftcode"
-        />
+        <Stack>
+          <Image
+            src="/images/logo_and_text.png"
+            height={500}
+            width={680}
+            alt="wecraftcode"
+            layout='intrinsic'
+          />
+        </Stack>
         <Stack className="text-center">
           <div className="py-4 lg:text-4xl lg:max-w-[800px]">
             We are a small group of people who leverage learning and programming


### PR DESCRIPTION
Fixed pages responsive in both home and about us page.
**Home** - In some smaller screen resolutions logo would appear squeeze. And in bigger resolutions logo was not showing
**About Us** - bigger resolutions, footer background color was showing white.

**ScreenShots - Home**
<img width="380" alt="wcc-home-01" src="https://user-images.githubusercontent.com/70811024/190888497-f13c848f-7d3e-4445-a207-172ebc70dc1c.png">
<img width="744" alt="wcc-home-02" src="https://user-images.githubusercontent.com/70811024/190888501-e8737aa2-4623-4d8c-a664-20c834dbee37.png">

**ScreenShots - About us**
<img width="1486" alt="wcc-aboutus-01" src="https://user-images.githubusercontent.com/70811024/190888504-bf9bdd17-dac5-4ed6-afa6-3bac495469c0.png">
